### PR TITLE
Increase BoneShield Cone. Ref. Issue #78, sect B.

### DIFF
--- a/source/lua/SiegeBalance/Onos.lua
+++ b/source/lua/SiegeBalance/Onos.lua
@@ -27,7 +27,7 @@ local function GetHitsBoneShield(self, doer, hitPoint)
     
         local viewDirection = GetNormalizedVectorXZ( self:GetViewCoords().zAxis )
         local zPosition = viewDirection:DotProduct( GetNormalizedVector( hitPoint - self:GetOrigin() ) )
-        return zPosition >= 0.34 --approx 115 degree cone of Onos facing
+        return zPosition >= 0.27 --approx 165 degree cone of Onos facing. Was 0.34 (~140 deg)
     
     end
     


### PR DESCRIPTION
Decreased return zPosition of boneshield from 0.34 to 0.27 (~140 deg to ~165 deg). Ref. Issue #78, sect B.