### PR TITLE
Increase BoneShield Cone. Ref. Issue #78, sect B.

### DIFF
--- a/source/lua/SiegeBalance/Onos.lua
+++ b/source/lua/SiegeBalance/Onos.lua
@@ -27,7 +27,7 @@ local function GetHitsBoneShield(self, doer, hitPoint)
     
         local viewDirection = GetNormalizedVectorXZ( self:GetViewCoords().zAxis )
         local zPosition = viewDirection:DotProduct( GetNormalizedVector( hitPoint - self:GetOrigin() ) )
-        return zPosition >= 0.34 --approx 115 degree cone of Onos facing
+        return zPosition >= 0.13 --approx 165 degree cone of Onos facing. Was 0.34 (~140 deg)
     
     end
     


### PR DESCRIPTION
Decreased return zPosition of boneshield from 0.34 to 0.13 (~140 deg to ~165 deg). Ref. Issue #78, sect B.

Proof:
cos^-1(0.34)= 70.12 * 2 =140.24
cos^-1(0.13)= 82.53 * 2 = 165.02